### PR TITLE
Feature/numeric differentiation for procedural validation and unit tests

### DIFF
--- a/runtest.sh
+++ b/runtest.sh
@@ -2,4 +2,4 @@
 # Run unit tests with julia and precompilation disabled
 mkdir -p './test/artifacts/'
 rm -rf './test/artifacts/*'
-julia --compiled-modules=no --code-coverage=user --project=. -e 'using Pkg; Pkg.test()'
+TEST='true' julia --compiled-modules=no --code-coverage=user --project=. -e 'using Pkg; Pkg.test()'

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -427,28 +427,6 @@ function query_node(g::ADGraph, name::String)::NodeID
     throw("Node not found")
 end
 
-function numeric_gradient(node::NodeID, wrt::Vector{NodeID}; delta=1e-3, iters=100)::Vector{MathObj}
-    grads = [zeros(size(val(i))) for i in wrt]
-    y = val(node)
-
-    for _ in 1:iters
-        for (n, i) in enumerate(wrt)
-            input = deepcopy(i)
-            dx = randn(size(val(input))) * delta
-            set!(input, val(input) + dx)
-
-            dy = val(NodeID(node.id, input.source)) - y
-            for dy in dy
-                grads[n] += dy ./ dx
-            end
-
-            grads[n] /= length(dy)
-        end
-    end
-
-    [grad / iters for grad in grads]
-end
-
 function Δ(f, wrt; cuda=false)
     v = val(f)
     od = if typeof(v) <: Number
@@ -471,92 +449,101 @@ function func(f::NodeID, params::NodeID...)::Function
     end
 end
 
-## Unit tests
-@testset "autodiff.jl" begin
-    @testset "Basic scalar AD" begin
-        local g = ADGraph()
-        local a = push!(g, 3)
+if ENV["TEST"]=="true"
+    using Pkg
+    Pkg.add("FiniteDiff")
+    using FiniteDiff
 
-        local b = push!(g, 4)
-        local c = a * b
-        @test(val(a) == 3)
-        @test(val(c) == 3 * 4)
-        local db = Δ!(c, wrt(b))
-        @test(val(db) == 3)
-
-        local d = push!(g, 5)
-        local e = c + d
-        local f = e * push!(g, 2)
-
-        @test(val(Δ(f, d)) == 2)
-        @test(val(Δ(f, c)) == 2)
-        @test(val(Δ(f, b)) == 6)
-    end
-
-    @testset "Basic matrix tests + (mby) CUDA" begin
-        local g = ADGraph()
-        #local a = transpose(push!(g, CuArray([1 2; 3 4; 5 6])))
-        #local b = push!(g, transpose(CuArray([1 2 3 0; 4 5 6 0; 7 8 9 0])))
-        #local d = push!(g, CUDA.ones(2, 4))
-
-        local a = transpose(push!(g, [1 2; 3 4; 5 6]))
-        local b = push!(g, transpose([1 2 3 0; 4 5 6 0; 7 8 9 0]))
-        local d = push!(g, ones(2, 4))
-
-        local c = exp(d) + a * transpose(b)
-        local c = c * b + a
-
-        local da = val(Δ(c, a))
-        local db = val(Δ(c, b))
-        local dd = val(Δ(c, d))
-        #gn = length(g.nodes)
-        #local bruh = c*b
-        #@assert(gn == length(g.nodes), keys(g.cache))
-
-        @test(size(da) == size(val(a)))
-        @test(size(db) == size(val(b)))
-        @test(size(dd) == size(val(d)))
-
-
-        using FiniteDiff
-        @test val(c) == func(c, d)(val(d))
-
-        dd2 = sum(FiniteDiff.finite_difference_jacobian(func(c, d), val(d)), dims=1)
-
-        for (a,b) in zip(dd2, dd)
-            @test abs(a-b) < 1e-3
+    function validate_func(f::NodeID, params::NodeID...)
+        for param in params
+            dd = convert.(Float64, val(Δ(f, param)))
+            x = convert.(Float64, val(param))
+            dd2 = sum(FiniteDiff.finite_difference_jacobian(func(f, param), x), dims=1)
+            for (a,b) in zip(dd2, dd)
+                @test abs(a-b) < 1e-3
+            end
         end
     end
 
-    @testset "Softmax test" begin
-        local x = rand(1000)
-        local sm = exp.(x) / sum(exp.(x))
-        local dsm = sm .* (1 .- sm)
+    ## Unit tests
+    @testset "autodiff.jl" begin
+        @testset "Basic scalar AD" begin
+            local g = ADGraph()
+            local a = push!(g, 3)
 
-        local g = ADGraph()
-        local x = push!(g, x)
+            local b = push!(g, 4)
+            local c = a * b
+            @test(val(a) == 3)
+            @test(val(c) == 3 * 4)
+            local db = Δ!(c, wrt(b))
+            @test(val(db) == 3)
 
-        local sm2 = softmax(x)
-        local dsm2 = Δ(sm2, x)
+            local d = push!(g, 5)
+            local e = c + d
+            local f = e * push!(g, 2)
 
-        @test(sm ≈ val(sm2))
-        @test(dsm ≈ val(dsm2))
-    end
+            @test(val(Δ(f, d)) == 2)
+            @test(val(Δ(f, c)) == 2)
+            @test(val(Δ(f, b)) == 6)
+        end
 
-    @testset "cat and slice test" begin
-        #local g = ADGraph()
-        #local a = rand(g, (3, 4))
-        #local b = rand(g, (3, 4))
+        @testset "Basic matrix tests + (mby) CUDA" begin
+            local g = ADGraph()
+            #local a = transpose(push!(g, CuArray([1 2; 3 4; 5 6])))
+            #local b = push!(g, transpose(CuArray([1 2 3 0; 4 5 6 0; 7 8 9 0])))
+            #local d = push!(g, CUDA.ones(2, 4))
 
-        #local c = cat(a, elemmul(b, a), dims=2)
-        #local d = c[1:3, 3:5]
+            local a = transpose(push!(g, [1 2; 3 4; 5 6]))
+            local b = push!(g, transpose([1 2 3 0; 4 5 6 0; 7 8 9 0]))
+            local d = push!(g, ones(2, 4))
 
-        #local db = Δ(c, b)
-        #local da = Δ(d, a)
+            local c = exp(d) + a * transpose(b)
+            local c = c * b + a
 
-        #@test(val(db) == val(a))
-        ##println(val(da, debug=true))
-        #e = cat(a, push!(g, nothing), dims=1)
-        #@test val(e) == val(a)
+            local da = val(Δ(c, a))
+            local db = val(Δ(c, b))
+            local dd = val(Δ(c, d))
+            #gn = length(g.nodes)
+            #local bruh = c*b
+            #@assert(gn == length(g.nodes), keys(g.cache))
+
+            @test(size(da) == size(val(a)))
+            @test(size(db) == size(val(b)))
+            @test(size(dd) == size(val(d)))
+
+            validate_func(c, a, b, d)
+        end
+
+        @testset "Softmax test" begin
+            local x = rand(1000)
+            local sm = exp.(x) / sum(exp.(x))
+            local dsm = sm .* (1 .- sm)
+
+            local g = ADGraph()
+            local x = push!(g, x)
+
+            local sm2 = softmax(x)
+            local dsm2 = Δ(sm2, x)
+
+            @test(sm ≈ val(sm2))
+            @test(dsm ≈ val(dsm2))
+        end
+
+        @testset "cat and slice test" begin
+            #local g = ADGraph()
+            #local a = rand(g, (3, 4))
+            #local b = rand(g, (3, 4))
+
+            #local c = cat(a, elemmul(b, a), dims=2)
+            #local d = c[1:3, 3:5]
+
+            #local db = Δ(c, b)
+            #local da = Δ(d, a)
+
+            #@test(val(db) == val(a))
+            ##println(val(da, debug=true))
+            #e = cat(a, push!(g, nothing), dims=1)
+            #@test val(e) == val(a)
+        end
     end
 end

--- a/src/numeric.jl
+++ b/src/numeric.jl
@@ -1,0 +1,21 @@
+function numeric_gradient(node::NodeID, wrt::Vector{NodeID}; delta=1e-3, iters=100)::Vector{MathObj}
+    grads = [zeros(size(val(i))) for i in wrt]
+    y = val(node)
+
+    for _ in 1:iters
+        for (n, i) in enumerate(wrt)
+            input = deepcopy(i)
+            dx = randn(size(val(input))) * delta
+            set!(input, val(input) + dx)
+
+            dy = val(NodeID(node.id, input.source)) - y
+            for dy in dy
+                grads[n] += dy ./ dx
+            end
+
+            grads[n] /= length(dy)
+        end
+    end
+
+    [grad / iters for grad in grads]
+end


### PR DESCRIPTION
Using `FiniteDiff.jl` to procedurally validate differentiation of any arbitrary expression for a given input.